### PR TITLE
FIX: Do not constrain trialinfo array to 3 columns

### DIFF
--- a/+spy/ft_save_spy.m
+++ b/+spy/ft_save_spy.m
@@ -60,7 +60,7 @@ for iTrial = 1:length(datain.trial)
     indx = indx + length(datain.time{iTrial});
 end
 if isfield(datain, 'trialinfo')
-    trl(:, 4:6) = datain.trialinfo;
+    trl(:, 4:end) = datain.trialinfo;
 end
 
 log = 'Created some test data';


### PR DESCRIPTION
- do not only save 3 cols of trialinfo, but the whole array
- closes #4 